### PR TITLE
Splitted encoder / decoder in VAEs models, and use only one class for VAE

### DIFF
--- a/surfify/losses/vae.py
+++ b/surfify/losses/vae.py
@@ -17,10 +17,30 @@ from torch.nn import functional as func
 from torch.distributions import Normal, kl_divergence
 
 
+def log_likelihood(recon, xs):
+    """ Computes the log likelihood of the input sample given the reconstructed
+    sample
+
+    Parameters
+    ----------
+    recon: Tensor (N, C, H, W)
+        reconstructed images
+    xs: Tensor (N, C, H, W)
+        original images
+
+    Returns
+    -------
+    log_likelihoods: Tensor (N)
+        log likelihood for each sample
+    """
+    return -Normal(recon, torch.ones_like(recon)).log_prob(xs).sum(
+        dim=tuple(range(1, recon.ndim)))
+
+
 class SphericalVAELoss(object):
     """ Spherical VAE Loss.
     """
-    def __init__(self, beta=9, left_mask=None, right_mask=None):
+    def __init__(self, beta=9, left_mask=None, right_mask=None, use_mse=True):
         """ Init class.
 
         Parameters
@@ -31,12 +51,15 @@ class SphericalVAELoss(object):
             left cortical binary mask.
         right_mask: Tensor (azimuth, elevation), default None
             right cortical binary mask.
+        use_mse: bool, default True
+            optionally uses the log likelihood.
         """
         super(SphericalVAELoss, self).__init__()
         self.beta = beta
         self.left_mask = left_mask
         self.right_mask = right_mask
         self.layer_outputs = None
+        self.use_mse = use_mse
 
     def __call__(self, left_recon_x, right_recon_x, left_x, right_x):
         """ Compute loss.
@@ -54,19 +77,28 @@ class SphericalVAELoss(object):
             self.right_mask = torch.ones(
                 (right_x.shape[-2], right_x.shape[-1]), dtype=int).to(device)
 
-        # Reconstruction loss term i.e. the mean squared error
-        left_mse = func.mse_loss(
-            left_recon_x * self.left_mask.detach(),
-            left_x * self.left_mask.detach(), reduction="mean")
-        right_mse = func.mse_loss(
-            right_recon_x * self.right_mask.detach(),
-            right_x * self.right_mask.detach(), reduction="mean")
+        # Reconstruction loss terms
+        if self.use_mse:
+            left_recon_loss = func.mse_loss(
+                left_recon_x * self.left_mask.detach(),
+                left_x * self.left_mask.detach(), reduction="mean")
+            right_recon_loss = func.mse_loss(
+                right_recon_x * self.right_mask.detach(),
+                right_x * self.right_mask.detach(), reduction="mean")
+        else:
+            left_recon_loss = log_likelihood(
+                left_recon_x * self.left_mask.detach(),
+                left_x * self.left_mask.detach()).mean()
+            right_recon_loss = log_likelihood(
+                right_recon_x * self.right_mask.detach(),
+                right_x * self.right_mask.detach()).mean()
 
         # Latent loss between approximate posterior and prior for z
         kl_div = kl_divergence(q, Normal(0, 1)).mean(dim=0).sum()
 
         # Need to maximise the ELBO with respect to these weights
-        loss = left_mse + right_mse + self.beta * kl_div
+        loss = left_recon_loss + right_recon_loss + self.beta * kl_div
 
-        return loss, {"left_mse": left_mse, "right_mse": right_mse,
-                      "kl_div": kl_div}
+        return loss, {"left_recon_loss": left_recon_loss,
+                      "right_recon_loss": right_recon_loss,
+                      "kl_div": kl_div, "beta": self.beta}

--- a/surfify/models/__init__.py
+++ b/surfify/models/__init__.py
@@ -13,7 +13,9 @@ Common architectures.
 
 from .base import SphericalBase
 from .unet import SphericalUNet, SphericalGUNet
-from .vae import SphericalVAE, SphericalGVAE
+from .vae import (
+    SphericalVAE, HemiFusionEncoder, HemiFusionDecoder,
+    SphericalHemiFusionEncoder, SphericalHemiFusionDecoder)
 from .vgg import (
     SphericalVGG, SphericalGVGG,
     SphericalVGG11, SphericalVGG13, SphericalVGG16, SphericalVGG19,

--- a/surfify/models/vae.py
+++ b/surfify/models/vae.py
@@ -18,6 +18,7 @@ Autoencoder: https://github.com/libilab/rsfMRI-VAE
 import torch
 import torch.nn as nn
 from torch.distributions import Normal
+from numpy import sqrt
 from ..utils import get_logger, debug_msg
 from ..nn import IcoUpConv, IcoPool, IcoSpMaConv, IcoSpMaConvTranspose
 from .base import SphericalBase
@@ -27,7 +28,7 @@ from .base import SphericalBase
 logger = get_logger()
 
 
-class SphericalVAE(SphericalBase):
+class SphericalVAE(nn.Module):
     """ Spherical VAE architecture.
 
     Use either RePa - Rectangular Patch convolution method or DiNe - Direct
@@ -62,10 +63,10 @@ class SphericalVAE(SphericalBase):
     >>> out = model(x, x)
     >>> print(out[0].shape, out[1].shape)
     """
-    def __init__(self, input_channels=1, input_order=5, latent_dim=64,
-                 conv_flts=[32, 32, 64, 64], conv_mode="DiNe", dine_size=1,
-                 repa_size=5, repa_zoom=5, dynamic_repa_zoom=False,
-                 fusion_level=1, standard_ico=False, cachedir=None):
+    def __init__(self, input_channels=1, input_order=5, input_dim=192,
+                 latent_dim=64, conv_flts=[32, 32, 64, 64], fusion_level=1,
+                 activation="LeakyReLU", batch_norm=False, conv_mode="DiNe",
+                 cachedir=None, encoder=None, decoder=None, *args, **kwargs):
         """ Init class.
 
         Parameters
@@ -101,105 +102,30 @@ class SphericalVAE(SphericalBase):
             set this folder to use smart caching speedup.
         """
         logger.debug("SphericalVAE init...")
-        super(SphericalVAE, self).__init__(
-            input_order=input_order, n_layers=len(conv_flts),
-            conv_mode=conv_mode, dine_size=dine_size, repa_size=repa_size,
-            repa_zoom=repa_zoom, dynamic_repa_zoom=dynamic_repa_zoom,
-            standard_ico=standard_ico, cachedir=cachedir)
-        self.input_channels = input_channels
-        self.latent_dim = latent_dim
-        self.conv_flts = conv_flts
-        self.top_flatten_dim = len(
-            self.ico[self.input_order - self.n_layers + 1].vertices)
-        self.top_final = self.conv_flts[-1] * self.top_flatten_dim
-        if fusion_level > self.n_layers or fusion_level <= 0:
-            raise ValueError("Impossible to use input fusion level with "
-                             "'{0}' layers.".format(self.n_layers))
-        self.fusion_level = fusion_level
-
-        # define the encoder
-        self.enc_left_conv = nn.Sequential()
-        self.enc_right_conv = nn.Sequential()
-        self.enc_w_conv = nn.Sequential()
-        multi_path = True
-        input_channels = self.input_channels
-        for idx in range(self.n_layers):
-            order = self.input_order - idx
-            if idx == self.fusion_level:
-                multi_path = False
-                input_channels *= 2
-            if idx != 0:
-                pooling = IcoPool(
-                    down_neigh_indices=self.ico[order + 1].neighbor_indices,
-                    down_indices=self.ico[order + 1].down_indices,
-                    pooling_type="mean")
-            if idx != 0 and multi_path:
-                self.enc_left_conv.add_module("pooling_{0}".format(idx),
-                                              pooling)
-                self.enc_right_conv.add_module("pooling_{0}".format(idx),
-                                               pooling)
-            elif idx != 0:
-                self.enc_w_conv.add_module("pooling_{0}".format(idx), pooling)
-            if multi_path:
-                output_channels = int(self.conv_flts[idx] / 2)
-                lconv = self.sconv(
-                    input_channels, output_channels,
-                    self.ico[order].conv_neighbor_indices)
-                self.enc_left_conv.add_module("l_enc_{0}".format(idx), lconv)
-                rconv = self.sconv(
-                    input_channels, output_channels,
-                    self.ico[order].conv_neighbor_indices)
-                self.enc_right_conv.add_module("r_enc_{0}".format(idx), rconv)
-                input_channels = output_channels
-            else:
-                conv = self.sconv(
-                    input_channels, self.conv_flts[idx],
-                    self.ico[order].conv_neighbor_indices)
-                self.enc_w_conv.add_module("enc_{0}".format(idx), conv)
-                input_channels = self.conv_flts[idx]
-        self.enc_w_dense = nn.Linear(self.top_final, self.latent_dim * 2)
-
-        # define the decoder
-        self.dec_w_dense = nn.Linear(self.latent_dim, self.top_final)
-        self.dec_w_conv = nn.Sequential()
-        self.dec_left_conv = nn.Sequential()
-        self.dec_right_conv = nn.Sequential()
-        input_channels = self.conv_flts[self.n_layers - 1]
-        if self.fusion_level == self.n_layers:
-            multi_path = True
-            input_channels = int(input_channels / 2)
-        else:
-            multi_path = False
-        for idx in range(self.n_layers - 1, -1, -1):
-            if multi_path:
-                if idx == 0:
-                    output_channels = self.input_channels
-                else:
-                    output_channels = int(self.conv_flts[idx - 1] / 2)
-                lconv = IcoUpConv(
-                    in_feats=input_channels, out_feats=output_channels,
-                    up_neigh_indices=self.ico[order].neighbor_indices,
-                    down_indices=self.ico[order].down_indices)
-                self.dec_left_conv.add_module("l_dec_{0}".format(idx), lconv)
-                rconv = IcoUpConv(
-                    in_feats=input_channels, out_feats=output_channels,
-                    up_neigh_indices=self.ico[order].neighbor_indices,
-                    down_indices=self.ico[order].down_indices)
-                self.dec_right_conv.add_module("r_dec_{0}".format(idx), rconv)
-                input_channels = output_channels
-            else:
-                conv = IcoUpConv(
-                    in_feats=input_channels, out_feats=self.conv_flts[idx - 1],
-                    up_neigh_indices=self.ico[order + 1].neighbor_indices,
-                    down_indices=self.ico[order + 1].down_indices)
-                self.dec_w_conv.add_module("dec_{0}".format(idx), conv)
-                input_channels = self.conv_flts[idx - 1]
-            if idx == self.fusion_level:
-                multi_path = True
-                input_channels = int(input_channels / 2)
-            order += 1
-
-        self.relu = nn.ReLU(inplace=True)
+        super().__init__()
+        assert conv_mode in ["DiNe", "RePa", "SpMa"]
+        use_grid = conv_mode == "SpMa"
+        if use_grid and encoder is None:
+            encoder = HemiFusionEncoder(
+                input_channels, input_dim, latent_dim * 2, conv_flts,
+                fusion_level, activation, batch_norm, *args, **kwargs)
+        elif encoder is None:
+            encoder = SphericalHemiFusionEncoder(
+                input_channels, input_order, latent_dim * 2, conv_flts,
+                fusion_level, activation, batch_norm, conv_mode,
+                cachedir=cachedir, *args, **kwargs)
+        if use_grid and decoder is None:
+            decoder = HemiFusionDecoder(
+                [input_channels, input_dim, input_dim], encoder.flatten_dim,
+                latent_dim, conv_flts, fusion_level, activation, batch_norm,
+                *args, **kwargs)
+        elif decoder is None:
+            decoder = SphericalHemiFusionDecoder(
+                input_channels, input_order, latent_dim, conv_flts,
+                fusion_level, activation, batch_norm, conv_mode,
+                cachedir=cachedir, *args, **kwargs)
+        self.encoder = encoder
+        self.decoder = decoder
 
     def encode(self, left_x, right_x):
         """ The encoder.
@@ -216,17 +142,9 @@ class SphericalVAE(SphericalBase):
         q(z | x): Normal (batch_size, <latent_dim>)
             a Normal distribution.
         """
-        left_x = self._safe_forward(self.enc_left_conv, left_x,
-                                    act=self.relu, skip_last_act=True)
-        right_x = self._safe_forward(self.enc_right_conv, right_x,
-                                     act=self.relu, skip_last_act=True)
-        x = torch.cat((left_x, right_x), dim=1)
-        x = self.relu(x)
-        x = self._safe_forward(self.enc_w_conv, x, act=self.relu)
-        x = x.reshape(-1, self.top_final)
-        x = self.enc_w_dense(x)
+        x = self.encoder((left_x, right_x))
         z_mu, z_logvar = torch.chunk(x, chunks=2, dim=1)
-        return Normal(loc=z_mu, scale=z_logvar.exp().pow(0.5))
+        return Normal(loc=z_mu, scale=(z_logvar * 0.5).exp())
 
     def decode(self, z):
         """ The decoder.
@@ -238,31 +156,22 @@ class SphericalVAE(SphericalBase):
 
         Returns
         -------
-        left_recon_x: Tensor (samples, <input_channels>, azimuth, elevation)
+        left_recon_x: Tensor (samples, <input_channels>, n_vertices)
             reconstructed left cortical texture.
-        right_recon_x: Tensor (samples, <input_channels>, azimuth, elevation)
+        right_recon_x: Tensor (samples, <input_channels>, n_vertices)
             reconstructed right cortical texture.
         """
-        x = self.relu(self.dec_w_dense(z))
-        x = x.view(-1, self.conv_flts[-1], self.top_flatten_dim)
-        x = self._safe_forward(self.dec_w_conv, x, act=self.relu)
-        left_recon_x, right_recon_x = torch.chunk(x, chunks=2, dim=1)
-        left_recon_x = self._safe_forward(self.dec_left_conv, left_recon_x,
-                                          act=self.relu, skip_last_act=True)
-        right_recon_x = self._safe_forward(self.dec_right_conv, right_recon_x,
-                                           act=self.relu, skip_last_act=True)
+        left_recon_x, right_recon_x = self.decoder(z)
         return left_recon_x, right_recon_x
 
-    def reparameterize(self, q):
+    def reparameterize(self, q, sample=True):
         """ Implement the reparametrization trick.
         """
-        if self.training:
-            z = q.rsample()
-        else:
-            z = q.loc
-        return z
+        if sample:
+            return q.rsample()
+        return q.loc
 
-    def forward(self, left_x, right_x):
+    def forward(self, left_x, right_x, sample=True):
         """ The forward method.
 
         Parameters
@@ -285,7 +194,7 @@ class SphericalVAE(SphericalBase):
         q = self.encode(left_x, right_x)
         logger.debug(debug_msg("posterior loc", q.loc))
         logger.debug(debug_msg("posterior scale", q.scale))
-        z = self.reparameterize(q)
+        z = self.reparameterize(q, sample)
         logger.debug(debug_msg("z", z))
         left_recon_x, right_recon_x = self.decode(z)
         logger.debug(debug_msg("left recon cortical", left_recon_x))
@@ -293,39 +202,12 @@ class SphericalVAE(SphericalBase):
         return left_recon_x, right_recon_x, {"q": q, "z": z}
 
 
-class SphericalGVAE(nn.Module):
-    """ Spherical Grided VAE architecture.
-
-    Use SpMa - Spherical Mapping convolution method.
-
-    Notes
-    -----
-    Debuging messages can be displayed by changing the log level using
-    ``setup_logging(level='debug')``.
-
-    See Also
-    --------
-    SphericalVAE
-
-    References
-    ----------
-    Representation Learning of Resting State fMRI with Variational
-    Autoencoder, NeuroImage 2021.
-
-    Examples
-    --------
-    >>> import torch
-    >>> from surfify.models import SphericalGVAE
-    >>> x = torch.zeros((1, 2, 192, 192))
-    >>> model = SphericalGVAE(
-    >>>     input_channels=2, input_dim=192, latent_dim=64,
-    >>>     conv_flts=[64, 128, 128, 256, 256], fusion_level=2)
-    >>> print(model)
-    >>> out = model(x, x)
-    >>> print(out[0].shape, out[1].shape)
-    """
-    def __init__(self, input_channels=1, input_dim=192, latent_dim=64,
-                 conv_flts=[64, 128, 128, 256, 256], fusion_level=1):
+class SphericalHemiFusionEncoder(SphericalBase):
+    def __init__(self, input_channels, input_order, latent_dim,
+                 conv_flts=[64, 128, 128, 256, 256], fusion_level=1,
+                 activation="LeakyReLU", batch_norm=False,
+                 conv_mode="DiNe", dine_size=1, repa_size=5, repa_zoom=5,
+                 dynamic_repa_zoom=False, standard_ico=False, cachedir=None):
         """ Init class.
 
         Parameters
@@ -335,108 +217,384 @@ class SphericalGVAE(nn.Module):
         input_dim: int, default 192
             the size of the converted 3-D surface to the 2-D grid.
         latent_dim: int, default 64
-            the size of the stochastic latent state of the SVAE.
+            the size of the latent space it encodes to.
         conv_flts: list of int
             the size of convolutional filters.
         fusion_level: int, default 1
             at which max pooling level left and right hemisphere data
             are concatenated.
+        activation: str, default 'LeakyReLU'
+            activation function's class name in pytorch's nn module to use
+            after each convolution
+        batch_norm: bool, default False
+            optionally uses batch normalization after each convolution
         """
-        logger.debug("SphericalGVAE init...")
-        super(SphericalGVAE, self).__init__()
+        logger.debug("SphericalHemiFusionEncoder init...")
+        super().__init__(
+            input_order=input_order, n_layers=len(conv_flts),
+            conv_mode=conv_mode, dine_size=dine_size, repa_size=repa_size,
+            repa_zoom=repa_zoom, dynamic_repa_zoom=dynamic_repa_zoom,
+            standard_ico=standard_ico, cachedir=cachedir)
+        self.input_channels = input_channels
+        self.conv_flts = conv_flts
+        self.activation = getattr(nn, activation)(inplace=True)
+        self.n_vertices_down = len(
+            self.ico[self.input_order - self.n_layers].vertices)
+        logger.debug("  number of vertices small ico : {}".format(
+            self.n_vertices_down))
+        self.flatten_dim = conv_flts[-1] * self.n_vertices_down
+        logger.debug("  dimension for linear {}".format(self.flatten_dim))
+        if fusion_level > self.n_layers or fusion_level <= 0:
+            raise ValueError("Impossible to use input fusion level with "
+                             "'{0}' layers.".format(self.n_layers))
+        self.fusion_level = fusion_level
+        self.latent_dim = latent_dim
+        self.left_conv = nn.Sequential()
+        self.right_conv = nn.Sequential()
+        self.w_conv = nn.Sequential()
+        input_channels = self.input_channels
+        for idx in range(self.n_layers):
+            order = self.input_order - idx
+            output_channels = self.conv_flts[idx]
+            pooling = IcoPool(
+                down_neigh_indices=self.ico[order].neighbor_indices,
+                down_indices=self.ico[order].down_indices,
+                pooling_type="mean")
+            if idx < fusion_level:
+                output_channels = int(output_channels / 2)
+                lconv = self.sconv(
+                    input_channels, output_channels,
+                    self.ico[order].conv_neighbor_indices)
+                self.left_conv.add_module("l_conv_{0}".format(idx), lconv)
+                if batch_norm:
+                    self.left_conv.add_module(
+                        "l_bn_{0}".format(idx),
+                        nn.BatchNorm1d(output_channels))
+                self.left_conv.add_module("pooling_{0}".format(idx), pooling)
+                rconv = self.sconv(
+                    input_channels, output_channels,
+                    self.ico[order].conv_neighbor_indices)
+                self.right_conv.add_module("r_conv_{0}".format(idx), rconv)
+                if batch_norm:
+                    self.right_conv.add_module(
+                        "r_bn_{0}".format(idx),
+                        nn.BatchNorm1d(output_channels))
+                self.right_conv.add_module("pooling_{0}".format(idx), pooling)
+                input_channels = output_channels
+            else:
+                input_channels = self.conv_flts[idx - 1]
+                conv = self.sconv(
+                    input_channels, output_channels,
+                    self.ico[order].conv_neighbor_indices)
+                self.w_conv.add_module("conv_{0}".format(idx), conv)
+                if batch_norm:
+                    self.w_conv.add_module(
+                        "bn_{0}".format(idx),
+                        nn.BatchNorm1d(self.conv_flts[idx]))
+                self.w_conv.add_module("pooling_{0}".format(idx), pooling)
+        self.w_dense = nn.Linear(self.flatten_dim, self.latent_dim)
+
+    def forward(self, x):
+        """ The encoding.
+
+        Parameters
+        ----------
+        left_x: Tensor (batch_size, <input_channels>, n_vertices)
+            input left cortical textures.
+        right_x: Tensor (batch_size, <input_channels>, n_vertices)
+            input right cortical textures.
+
+        Returns
+        -------
+        x: Tensor (batch_size, <latent_dim>)
+            the latent representations.
+        """
+        left_x, right_x = x
+        logger.debug("SphericalHemiFusionEncoder forward pass")
+        logger.debug(debug_msg("  left cortical", left_x))
+        logger.debug(debug_msg("  right cortical", right_x))
+        left_x = self._safe_forward(
+            self.left_conv, left_x, act=self.activation, skip_last_act=True)
+        right_x = self._safe_forward(
+            self.right_conv, right_x, act=self.activation, skip_last_act=True)
+        logger.debug(debug_msg("  left enc", left_x))
+        logger.debug(debug_msg("  right enc", right_x))
+        x = torch.cat((left_x, right_x), dim=1)
+        x = self.activation(x)
+        logger.debug(debug_msg("  merged enc", x))
+        x = self._safe_forward(self.w_conv, x, act=self.activation)
+        logger.debug(debug_msg("  final conv enc", x))
+        x = x.view(-1, self.flatten_dim)
+        logger.debug(debug_msg("  flattened", x))
+        x = self.w_dense(x)
+        return x
+
+
+class SphericalHemiFusionDecoder(SphericalBase):
+    def __init__(self, input_channels, input_order, latent_dim,
+                 conv_flts=[64, 128, 128, 256, 256], fusion_level=1,
+                 activation="LeakyReLU", batch_norm=False,
+                 conv_mode="DiNe", dine_size=1, repa_size=5, repa_zoom=5,
+                 dynamic_repa_zoom=False, standard_ico=False, cachedir=None):
+        """ Init class.
+
+        Parameters
+        ----------
+        input_channels: int, default 1
+            the number of input channels.
+        input_dim: int, default 192
+            the size of the converted 3-D surface to the 2-D grid.
+        latent_dim: int, default 64
+            the size of the latent space it encodes to.
+        conv_flts: list of int
+            the size of convolutional filters.
+        fusion_level: int, default 1
+            at which max pooling level left and right hemisphere data
+            are concatenated.
+        activation: str, default 'LeakyReLU'
+            activation function's class name in pytorch's nn module to use
+            after each convolution
+        batch_norm: bool, default False
+            optionally uses batch normalization after each convolution
+        """
+        logger.debug("SphericalHemiFusionDecoder init...")
+        super().__init__(
+            input_order=input_order, n_layers=len(conv_flts),
+            conv_mode=conv_mode, dine_size=dine_size, repa_size=repa_size,
+            repa_zoom=repa_zoom, dynamic_repa_zoom=dynamic_repa_zoom,
+            standard_ico=standard_ico, cachedir=cachedir)
+        self.input_channels = input_channels
+        self.latent_dim = latent_dim
+        self.conv_flts = conv_flts
+
+        self.activation = getattr(nn, activation)(inplace=True)
+        self.n_vertices_down = len(
+            self.ico[self.input_order - self.n_layers].vertices)
+        logger.debug("  number of vertices small ico : {}".format(
+            self.n_vertices_down))
+        self.flatten_dim = conv_flts[-1] * self.n_vertices_down
+        logger.debug("  dimension for linear {}".format(self.flatten_dim))
+        if fusion_level > self.n_layers or fusion_level <= 0:
+            raise ValueError("Impossible to use input fusion level with "
+                             "'{0}' layers.".format(self.n_layers))
+        self.fusion_level = fusion_level
+        self.latent_dim = latent_dim
+
+        self.w_dense = nn.Linear(self.latent_dim, self.flatten_dim)
+        self.w_conv = nn.Sequential()
+        self.left_conv = nn.Sequential()
+        self.right_conv = nn.Sequential()
+        input_channels = self.conv_flts[self.n_layers - 1]
+        for idx in range(self.n_layers - 1, -1, -1):
+            order = self.input_order - idx - 1
+            input_channels = self.conv_flts[idx]
+            output_channels = self.input_channels * 2
+            if idx != 0:
+                output_channels = self.conv_flts[idx - 1]
+            if idx < fusion_level:
+                output_channels = int(output_channels / 2)
+                input_channels = int(input_channels / 2)
+                logger.debug("input channels : {}".format(input_channels))
+                logger.debug("output channels : {}".format(output_channels))
+                l_pooling = IcoUpConv(
+                    in_feats=input_channels, out_feats=output_channels,
+                    up_neigh_indices=self.ico[order + 1].neighbor_indices,
+                    down_indices=self.ico[order + 1].down_indices)
+                lconv = self.sconv(
+                    output_channels, output_channels,
+                    self.ico[order + 1].conv_neighbor_indices)
+                self.left_conv.add_module(
+                    "l_pooling_{0}".format(idx), l_pooling)
+                self.left_conv.add_module("l_conv_{0}".format(idx), lconv)
+                if batch_norm:
+                    self.left_conv.add_module(
+                        "l_bn_{0}".format(idx),
+                        nn.BatchNorm1d(output_channels))
+                r_pooling = IcoUpConv(
+                    in_feats=input_channels, out_feats=output_channels,
+                    up_neigh_indices=self.ico[order + 1].neighbor_indices,
+                    down_indices=self.ico[order + 1].down_indices)
+                rconv = self.sconv(
+                    output_channels, output_channels,
+                    self.ico[order + 1].conv_neighbor_indices)
+                self.right_conv.add_module(
+                    "r_pooling_{0}".format(idx), r_pooling)
+                self.right_conv.add_module("r_conv_{0}".format(idx), rconv)
+                if batch_norm:
+                    self.right_conv.add_module(
+                        "r_bn_{0}".format(idx),
+                        nn.BatchNorm1d(output_channels))
+            else:
+                logger.debug("input channels : {}".format(input_channels))
+                logger.debug("output channels : {}".format(output_channels))
+                logger.debug("order : {}".format(order))
+                pooling = IcoUpConv(
+                    in_feats=input_channels, out_feats=output_channels,
+                    up_neigh_indices=self.ico[order + 1].neighbor_indices,
+                    down_indices=self.ico[order + 1].down_indices)
+                conv = self.sconv(
+                    output_channels, output_channels,
+                    self.ico[order + 1].conv_neighbor_indices)
+                self.w_conv.add_module("pooling_{0}".format(idx), pooling)
+                self.w_conv.add_module("conv_{0}".format(idx), conv)
+                if batch_norm:
+                    self.w_conv.add_module(
+                        "bn_{0}".format(idx),
+                        nn.BatchNorm1d(self.conv_flts[idx]))
+
+    def forward(self, x):
+        """ The decoding.
+
+        Parameters
+        ----------
+        left_x: Tensor (batch_size, <input_channels>, n_vertices)
+            input left cortical textures.
+        right_x: Tensor (batch_size, <input_channels>, n_vertices)
+            input right cortical textures.
+
+        Returns
+        -------
+        x: Tensor (batch_size, <latent_dim>)
+            the latent representations.
+        """
+        logger.debug("SphericalHemiFusionDecoder forward pass")
+        logger.debug(debug_msg("latent", x))
+        x = self.activation(self.w_dense(x))
+        x = x.view(-1, self.conv_flts[-1], self.n_vertices_down)
+        logger.debug(debug_msg("input to conv", x))
+        x = self._safe_forward(self.w_conv, x, act=self.activation)
+        logger.debug(debug_msg("before hemi sep", x))
+        left_x, right_x = torch.chunk(x, chunks=2, dim=1)
+        logger.debug(debug_msg("after hemi sep right", right_x))
+        logger.debug(debug_msg("after hemi sep left", left_x))
+        left_x = self._safe_forward(self.left_conv, left_x,
+                                    act=self.activation, skip_last_act=True)
+        right_x = self._safe_forward(self.right_conv, right_x,
+                                     act=self.activation, skip_last_act=True)
+        return left_x, right_x
+
+
+def compute_output_dim(input_dim, convnet):
+    """ Compute the output dimension of a convolutional network
+    that takes as input a square input (H = W)
+
+    Parameters
+    ----------
+    input_dim: int
+        input height and weight
+    convnet: iterable[nn.Module]
+        iterable containing the various layers. For now, the function
+        can only work with nn.Conv2d and IcoSpMaConv layers
+
+    Returns
+    -------
+    output_dim: int
+        output dimension
+    """
+    output_dim = input_dim
+    for layer in convnet:
+        if type(layer) is nn.Conv2d:
+            output_dim = int(
+                (output_dim + 2 * layer.padding[0] - layer.dilation[0] *
+                 (layer.kernel_size[0] - 1) - 1) / layer.stride[0] + 1)
+        elif type(layer) is IcoSpMaConv:
+            output_dim = compute_output_dim(
+                output_dim + 2 * layer.pad, [layer.conv])
+    return output_dim
+
+
+class HemiFusionEncoder(nn.Module):
+    def __init__(self, input_channels, input_dim, latent_dim,
+                 conv_flts=[64, 128, 128, 256, 256], fusion_level=1,
+                 activation="LeakyReLU", batch_norm=False, return_dist=True):
+        """ Init class.
+
+        Parameters
+        ----------
+        input_channels: int, default 1
+            the number of input channels.
+        input_dim: int, default 192
+            the size of the converted 3-D surface to the 2-D grid.
+        latent_dim: int, default 64
+            the size of the latent space it encodes to.
+        conv_flts: list of int
+            the size of convolutional filters.
+        fusion_level: int, default 1
+            at which max pooling level left and right hemisphere data
+            are concatenated.
+        activation: str, default 'LeakyReLU'
+            activation function's class name in pytorch's nn module to use
+            after each convolution
+        batch_norm: bool, default False
+            optionally uses batch normalization after each convolution
+        """
+        logger.debug("HemiFusionEncoder init...")
+        super().__init__()
         self.input_channels = input_channels
         self.input_dim = input_dim
         self.latent_dim = latent_dim
         self.conv_flts = conv_flts
         self.n_layers = len(self.conv_flts)
-        self.top_flatten_dim = int(self.input_dim / (2 ** self.n_layers))
-        self.top_final = self.conv_flts[-1] * self.top_flatten_dim ** 2
         if fusion_level > self.n_layers or fusion_level <= 0:
             raise ValueError("Impossible to use input fusion level with "
                              "'{0}' layers.".format(self.n_layers))
         self.fusion_level = fusion_level
-
-        # define the encoder
-        self.enc_left_conv = nn.Sequential()
-        self.enc_right_conv = nn.Sequential()
-        self.enc_w_conv = nn.Sequential()
-        multi_path = True
+        self.left_conv = nn.Sequential()
+        self.right_conv = nn.Sequential()
+        self.w_conv = nn.Sequential()
         input_channels = self.input_channels
         for idx in range(self.n_layers):
-            if idx == self.fusion_level:
-                multi_path = False
-                input_channels *= 2
-            if multi_path:
-                output_channels = int(self.conv_flts[idx] / 2)
-                if idx == 0:
-                    kernel_size = 8
-                    pad = 3
-                else:
-                    kernel_size = 4
-                    pad = 1
+            if idx == 0:
+                kernel_size = 8
+                pad = 3
+            else:
+                kernel_size = 4
+                pad = 1
+            output_channels = self.conv_flts[idx]
+            if idx < fusion_level:
+                output_channels /= 2
                 lconv = IcoSpMaConv(
-                    in_feats=input_channels, out_feats=output_channels,
+                    in_feats=input_channels, out_feats=int(output_channels),
                     kernel_size=kernel_size, stride=2, pad=pad)
-                self.enc_left_conv.add_module("l_enc_{0}".format(idx), lconv)
+                self.left_conv.add_module("l_conv_{0}".format(idx), lconv)
+                if batch_norm:
+                    self.left_conv.add_module(
+                        "l_bn_{0}".format(idx),
+                        nn.BatchNorm2d(int(output_channels)))
+                self.left_conv.add_module(
+                    "l_act_{0}".format(idx),
+                    getattr(nn, activation)(inplace=True))
                 rconv = IcoSpMaConv(
-                    in_feats=input_channels, out_feats=output_channels,
+                    in_feats=input_channels, out_feats=int(output_channels),
                     kernel_size=kernel_size, stride=2, pad=pad)
-                self.enc_right_conv.add_module("r_enc_{0}".format(idx), rconv)
-                input_channels = output_channels
+                self.right_conv.add_module("r_conv_{0}".format(idx), rconv)
+                if batch_norm:
+                    self.right_conv.add_module(
+                        "r_bn_{0}".format(idx),
+                        nn.BatchNorm2d(int(output_channels)))
+                self.right_conv.add_module(
+                    "r_act_{0}".format(idx),
+                    getattr(nn, activation)(inplace=True))
+                input_channels = int(output_channels)
             else:
-                conv = IcoSpMaConv(
-                    input_channels, self.conv_flts[idx], kernel_size=4,
-                    stride=2, pad=1)
-                self.enc_w_conv.add_module("enc_{0}".format(idx), conv)
-                input_channels = self.conv_flts[idx]
-        self.enc_w_dense = nn.Linear(self.top_final, self.latent_dim * 2)
-
-        # define the decoder
-        self.dec_w_dense = nn.Linear(self.latent_dim, self.top_final)
-        self.dec_w_conv = nn.Sequential()
-        self.dec_left_conv = nn.Sequential()
-        self.dec_right_conv = nn.Sequential()
-        input_channels = self.conv_flts[self.n_layers - 1]
-        if self.fusion_level == self.n_layers:
-            multi_path = True
-            input_channels = int(input_channels / 2)
-        else:
-            multi_path = False
-        for idx in range(self.n_layers - 1, -1, -1):
-            if multi_path:
-                if idx == 0:
-                    kernel_size = 8
-                    pad = 3
-                    zero_pad = 9
-                    output_channels = self.input_channels
-                else:
-                    kernel_size = 4
-                    pad = 1
-                    zero_pad = 3
-                    output_channels = int(self.conv_flts[idx - 1] / 2)
-                lconv = IcoSpMaConvTranspose(
-                    in_feats=input_channels, out_feats=output_channels,
-                    kernel_size=kernel_size, stride=2, pad=pad,
-                    zero_pad=zero_pad)
-                self.dec_left_conv.add_module("l_dec_{0}".format(idx), lconv)
-                rconv = IcoSpMaConvTranspose(
-                    in_feats=input_channels, out_feats=output_channels,
-                    kernel_size=kernel_size, stride=2, pad=pad,
-                    zero_pad=zero_pad)
-                self.dec_right_conv.add_module("r_dec_{0}".format(idx), rconv)
-                input_channels = output_channels
-            else:
-                conv = IcoSpMaConvTranspose(
-                    in_feats=input_channels, out_feats=self.conv_flts[idx - 1],
-                    kernel_size=4, stride=2, pad=1, zero_pad=3)
-                self.dec_w_conv.add_module("dec_{0}".format(idx), conv)
                 input_channels = self.conv_flts[idx - 1]
-            if idx == self.fusion_level:
-                multi_path = True
-                input_channels = int(input_channels / 2)
-        self.relu = nn.ReLU(inplace=True)
+                conv = IcoSpMaConv(
+                    in_feats=input_channels, out_feats=self.conv_flts[idx],
+                    kernel_size=kernel_size, stride=2, pad=pad)
+                self.w_conv.add_module("conv_{0}".format(idx), conv)
+                if batch_norm:
+                    self.w_conv.add_module(
+                        "bn_{0}".format(idx),
+                        nn.BatchNorm2d(self.conv_flts[idx]))
+                self.w_conv.add_module("act_{0}".format(idx),
+                                       getattr(nn, activation)(inplace=True))
 
-    def encode(self, left_x, right_x):
+        self.output_dim = compute_output_dim(input_dim,
+                                             [*self.left_conv, *self.w_conv])
+        self.flatten_dim = self.output_dim ** 2 * self.conv_flts[-1]
+        self.w_dense = nn.Linear(self.flatten_dim, self.latent_dim)
+
+    def forward(self, x):
         """ The encoder.
 
         Parameters
@@ -451,18 +609,108 @@ class SphericalGVAE(nn.Module):
         q(z | x): Normal (batch_size, <latent_dim>)
             a Normal distribution.
         """
-        left_x = self.enc_left_conv(left_x)
-        right_x = self.enc_right_conv(right_x)
+        left_x, right_x = x
+        left_x = self.left_conv(left_x)
+        right_x = self.right_conv(right_x)
         x = torch.cat((left_x, right_x), dim=1)
-        x = self.relu(x)
-        for mod in self.enc_w_conv.children():
-            x = self.relu(mod(x))
-        x = x.view(-1, self.top_final)
-        x = self.enc_w_dense(x)
-        z_mu, z_logvar = torch.chunk(x, chunks=2, dim=1)
-        return Normal(loc=z_mu, scale=torch.exp(0.5 * z_logvar))
+        x = self.w_conv(x)
+        x = x.view(-1, self.flatten_dim)
+        z = self.w_dense(x)
+        return z
 
-    def decode(self, z):
+
+class HemiFusionDecoder(nn.Module):
+    def __init__(self, output_shape, before_latent_dim,
+                 latent_dim, conv_flts=[64, 128, 128, 256, 256],
+                 fusion_level=1, activation="LeakyReLU", batch_norm=False):
+        """ Init class.
+
+        Parameters
+        ----------
+        output_channels: int, default 1
+            the number of output channels.
+        input_dim: int,
+            the size of the squared input to the convnet, after the dense
+            layer transforming the input from the latent space.
+        latent_dim: int, default 64
+            the size of the latent space it decodes from.
+        conv_flts: list of int
+            the size of convolutional filters, given in reverse order: the
+            first filter in the list will be the last one in the network.
+        fusion_level: int, default 1
+            at which max pooling level left and right hemisphere data
+            are concatenated.
+        activation: str, default 'LeakyReLU'
+            activation function's class name in pytorch's nn module to use
+            after each convolution
+        batch_norm: bool, default False
+            optionally uses batch normalization after each convolution
+        """
+        logger.debug("HemiFusionDecoder init...")
+        super().__init__()
+
+        self.before_latent_dim = before_latent_dim
+        self.conv_flts = conv_flts.copy()
+        self.n_layers = len(conv_flts)
+        self.conv_flts.insert(0, output_shape[0]*2)
+        self.output_shape = output_shape
+        # flatten_dim = input_dim ** 2 * conv_flts[-1]
+        self.w_dense = nn.Linear(latent_dim, before_latent_dim)
+        self.w_conv = nn.Sequential()
+        self.left_conv = nn.Sequential()
+        self.right_conv = nn.Sequential()
+        self.fusion_level = fusion_level
+        for idx in range(self.n_layers, 0, -1):
+            kernel_size = 4
+            pad = 1
+            zero_pad = 3
+            output_shape = None
+            if idx == 1:
+                kernel_size = 8
+                pad = 1
+                zero_pad = 5 - (self.output_shape[1] % 8 // 2)
+                output_shape = self.output_shape
+
+            input_channels = self.conv_flts[idx]
+            output_channels = self.conv_flts[idx - 1]
+            if idx < fusion_level + 1:
+                input_channels = int(input_channels / 2)
+                output_channels = int(output_channels / 2)
+                lconv = IcoSpMaConvTranspose(
+                    in_feats=input_channels, out_feats=output_channels,
+                    kernel_size=kernel_size, stride=2, pad=pad,
+                    zero_pad=zero_pad, output_shape=output_shape)
+                if batch_norm:
+                    self.left_conv.add_module(
+                        "l_bn_{0}".format(idx),
+                        nn.BatchNorm2d(input_channels))
+                self.left_conv.add_module("l_act_{0}".format(idx),
+                                          getattr(nn, activation)())
+                self.left_conv.add_module("l_conv_{0}".format(idx), lconv)
+                rconv = IcoSpMaConvTranspose(
+                    in_feats=input_channels, out_feats=output_channels,
+                    kernel_size=kernel_size, stride=2, pad=pad,
+                    zero_pad=zero_pad, output_shape=output_shape)
+                if batch_norm:
+                    self.right_conv.add_module(
+                        "r_bn_{0}".format(idx),
+                        nn.BatchNorm2d(input_channels))
+                self.right_conv.add_module("r_act_{0}".format(idx),
+                                           getattr(nn, activation)())
+                self.right_conv.add_module("r_conv_{0}".format(idx), rconv)
+            else:
+                conv = IcoSpMaConvTranspose(
+                    input_channels, output_channels, kernel_size=kernel_size,
+                    stride=2, pad=pad, zero_pad=zero_pad)
+                if batch_norm and idx != self.n_layers:
+                    self.w_conv.add_module(
+                        "bn_{0}".format(idx),
+                        nn.BatchNorm2d(output_channels))
+                self.w_conv.add_module("act_{0}".format(idx),
+                                       getattr(nn, activation)(inplace=True))
+                self.w_conv.add_module("conv_{0}".format(idx), conv)
+
+    def forward(self, z):
         """ The decoder.
 
         Parameters
@@ -477,51 +725,13 @@ class SphericalGVAE(nn.Module):
         right_recon_x: Tensor (samples, <input_channels>, azimuth, elevation)
             reconstructed right cortical texture.
         """
-        x = self.relu(self.dec_w_dense(z))
-        x = x.view(-1, self.conv_flts[-1], self.top_flatten_dim,
-                   self.top_flatten_dim)
-        for mod in self.dec_w_conv.children():
-            x = self.relu(mod(x))
+        x = self.w_dense(z)
+        remaining_shape = int(sqrt(
+            x.shape[1] / self.conv_flts[-1]))
+        x = x.view(len(x), self.conv_flts[-1], remaining_shape,
+                   remaining_shape)
+        x = self.w_conv(x)
         left_recon_x, right_recon_x = torch.chunk(x, chunks=2, dim=1)
-        left_recon_x = self.dec_left_conv(left_recon_x)
-        right_recon_x = self.dec_right_conv(right_recon_x)
+        left_recon_x = self.left_conv(left_recon_x)
+        right_recon_x = self.right_conv(right_recon_x)
         return left_recon_x, right_recon_x
-
-    def reparameterize(self, q):
-        """ Implement the reparametrization trick.
-        """
-        if self.training:
-            z = q.rsample()
-        else:
-            z = q.loc
-        return z
-
-    def forward(self, left_x, right_x):
-        """ The forward method.
-
-        Parameters
-        ----------
-        left_x: Tensor (samples, <input_channels>, azimuth, elevation)
-            input left cortical texture.
-        right_x: Tensor (samples, <input_channels>, azimuth, elevation)
-            input right cortical texture.
-
-        Returns
-        -------
-        left_recon_x: Tensor (samples, <input_channels>, azimuth, elevation)
-            reconstructed left cortical texture.
-        right_recon_x: Tensor (samples, <input_channels>, azimuth, elevation)
-            reconstructed right cortical texture.
-        """
-        logger.debug("SphericalGVAE forward pass")
-        logger.debug(debug_msg("left cortical", left_x))
-        logger.debug(debug_msg("right cortical", right_x))
-        q = self.encode(left_x, right_x)
-        logger.debug(debug_msg("posterior loc", q.loc))
-        logger.debug(debug_msg("posterior scale", q.scale))
-        z = self.reparameterize(q)
-        logger.debug(debug_msg("z", z))
-        left_recon_x, right_recon_x = self.decode(z)
-        logger.debug(debug_msg("left recon cortical", left_recon_x))
-        logger.debug(debug_msg("right recon cortical", right_recon_x))
-        return left_recon_x, right_recon_x, {"q": q, "z": z}

--- a/surfify/nn/modules.py
+++ b/surfify/nn/modules.py
@@ -111,7 +111,7 @@ class IcoSpMaConvTranspose(nn.Module):
     >>> proj_ico_x.shape
     """
     def __init__(self, in_feats, out_feats, kernel_size, stride=1, pad=0,
-                 zero_pad=0):
+                 zero_pad=0, output_shape=None):
         """ Init IcoSpMaConvTranspose.
 
         Parameters
@@ -127,7 +127,7 @@ class IcoSpMaConvTranspose(nn.Module):
         pad: int or tuple (pad_azimuth, pad_elevation), default 0
             the size of the padding.
         zero_pad: int or tuple, default 0
-            add a zero padding in both axis before the transpose convolution.
+            add a zero padding in both axes before the transpose convolution.
         """
         super(IcoSpMaConvTranspose, self).__init__()
         self.in_feats = in_feats
@@ -136,6 +136,7 @@ class IcoSpMaConvTranspose(nn.Module):
         self.stride = stride
         self.pad = pad
         self.zero_pad = zero_pad
+        self.output_shape = output_shape
         self.tconv = nn.ConvTranspose2d(
             in_channels=in_feats,
             out_channels=out_feats,
@@ -146,7 +147,9 @@ class IcoSpMaConvTranspose(nn.Module):
         logger.debug(debug_msg("input", x))
         x = circular_pad(x, pad=self.pad)
         logger.debug(debug_msg("pad", x))
-        x = self.tconv(x)
+        output_size = ([len(x)] + self.output_shape if self.output_shape
+                       else None)
+        x = self.tconv(x, output_size=output_size)
         logger.debug(debug_msg("transpose conv", x))
         return x
 

--- a/surfify/tests/test_models_vae.py
+++ b/surfify/tests/test_models_vae.py
@@ -17,7 +17,7 @@ from surfify import datasets
 
 
 class TestModelsVAE(unittest.TestCase):
-    """ Test the SphericalVAE.
+    """ Test the SphericalVAE with DiNe and RePa.
     """
     def setUp(self):
         """ Setup test.
@@ -57,7 +57,7 @@ class TestModelsVAE(unittest.TestCase):
 
 
 class TestModelsGVAE(unittest.TestCase):
-    """ Test the SphericalVAE.
+    """ Test the SphericalVAE with SpMa on regrided data.
     """
     def setUp(self):
         """ Setup test.

--- a/surfify/tests/test_models_vae.py
+++ b/surfify/tests/test_models_vae.py
@@ -42,18 +42,22 @@ class TestModelsVAE(unittest.TestCase):
         """
         model = models.SphericalVAE(
             input_channels=self.n_classes, input_order=self.order,
-            latent_dim=32,  conv_mode="DiNe", dine_size=1,
+            latent_dim=32, conv_mode="DiNe", dine_size=1,
             conv_flts=[32, 64], standard_ico=True)
         out = model(self.X, self.X)
+        self.assertTrue(len(out) == 3)
+        self.assertTrue(out[0].shape == self.X.shape)
         model = models.SphericalVAE(
             input_channels=self.n_classes, input_order=self.order,
             latent_dim=32, conv_mode="RePa", repa_size=5, repa_zoom=5,
             conv_flts=[32, 64], standard_ico=True)
         out = model(self.X, self.X)
+        self.assertTrue(len(out) == 3)
+        self.assertTrue(out[0].shape == self.X.shape)
 
 
 class TestModelsGVAE(unittest.TestCase):
-    """ Test the SphericalGVAE.
+    """ Test the SphericalVAE.
     """
     def setUp(self):
         """ Setup test.
@@ -67,10 +71,13 @@ class TestModelsGVAE(unittest.TestCase):
             ico_vertices, n_samples=40, n_classes=self.n_classes, scale=1,
             seed=42)
         self.X = []
+        self.input_dim = 193
         for sample_idx in range(X.shape[0]):
             _X = []
             for ch_idx in range(X.shape[1]):
-                _X.append(utils.text2grid(ico_vertices, X[sample_idx, ch_idx]))
+                _X.append(utils.text2grid(
+                    ico_vertices, X[sample_idx, ch_idx], resx=self.input_dim,
+                    resy=self.input_dim))
             self.X.append(_X)
         self.X = np.asarray(self.X)
         self.X = torch.from_numpy(self.X)
@@ -81,12 +88,14 @@ class TestModelsGVAE(unittest.TestCase):
         pass
 
     def test_forward(self):
-        """ Test SphericalGVAE forward.
+        """ Test SphericalVAE forward.
         """
-        model = models.SphericalGVAE(
-            input_channels=self.n_classes, input_dim=194, latent_dim=32,
-            conv_flts=[64, 128, 128])
+        model = models.SphericalVAE(
+            input_channels=self.n_classes, input_dim=self.input_dim,
+            latent_dim=32, conv_flts=[64, 128, 128], conv_mode="SpMa")
         out = model(self.X, self.X)
+        self.assertTrue(len(out) == 3)
+        self.assertTrue(out[0].shape == self.X.shape)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The VAE can use either SpMa conv (on regrided data) operator, or DiNe / RePa operators (on the mesh directly), creating the corresponding encoder/decoder